### PR TITLE
Move offer flow to API user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,6 +1675,7 @@ dependencies = [
 name = "servo-media-gstreamer"
 version = "0.1.0"
 dependencies = [
+ "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1706,6 +1707,9 @@ dependencies = [
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
+dependencies = [
+ "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "servo_media_android"

--- a/backends/gstreamer/Cargo.toml
+++ b/backends/gstreamer/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 regex = "1.0"
 zip = "0.3.1"
 
+[dependencies]
+boxfnonce = "0.1.0"
+
 [dependencies.byte-slice-cast]
 version = "0.2"
 

--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate boxfnonce;
 extern crate byte_slice_cast;
 extern crate failure;
 extern crate glib;

--- a/backends/gstreamer/src/webrtc.rs
+++ b/backends/gstreamer/src/webrtc.rs
@@ -101,7 +101,7 @@ impl GStreamerWebRtcController {
 
         let kind = if local { "set-local-description" } else { "set-remote-description" };
 
-        let mut app_control = self.0.lock().unwrap();
+        let app_control = self.0.lock().unwrap();
         let ret = gst_sdp::SDPMessage::parse_buffer(desc.sdp.as_bytes()).unwrap();
         let answer =
             gst_webrtc::WebRTCSessionDescription::new(ty, ret);

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -97,8 +97,8 @@ impl ServoMedia {
         Box::new(Backend::make_player())
     }
 
-    pub fn create_webrtc(&self, signaller: Box<WebRtcSignaller>) -> Box<WebRtcController> {
-        Box::new(Backend::start_webrtc_controller(
+    pub fn create_webrtc_arc(&self, signaller: Box<WebRtcSignaller>) -> Arc<WebRtcController> {
+        Arc::new(Backend::start_webrtc_controller(
             signaller,
             &*Self::create_audiostream(),
             &*Self::create_videostream()),

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 
 [dependencies]
+boxfnonce = "0.1.0"


### PR DESCRIPTION
there are some reentrancy issues here, I think the best solution here is to eventually wrap an "RTC manager thread" around this and expose it instead.

From Servo DOM's point of view the reentrancy issues are irrelevant since all callbacks will be spawning tasks on the main thread anyway.

r? @jdm