### PR TITLE
hacky support for other side of RTC

### DIFF
--- a/backends/gstreamer/src/lib.rs
+++ b/backends/gstreamer/src/lib.rs
@@ -20,7 +20,7 @@ extern crate servo_media_webrtc;
 use servo_media_audio::sink::AudioSinkError;
 use servo_media_audio::AudioBackend;
 use servo_media_player::PlayerBackend;
-use servo_media_webrtc::{WebRtcBackend, WebRtcSignaller, MediaStream};
+use servo_media_webrtc::{WebRtcBackend, WebRtcSignaller};
 
 pub mod audio_decoder;
 pub mod audio_sink;
@@ -51,12 +51,10 @@ impl PlayerBackend for GStreamerBackend {
 impl WebRtcBackend for GStreamerBackend {
     type Controller = webrtc::GStreamerWebRtcController;
 
-    fn start_webrtc_controller(
+    fn construct_webrtc_controller(
         signaller: Box<WebRtcSignaller>,
-        audio: &MediaStream,
-        video: &MediaStream,
     ) -> Self::Controller {
-        webrtc::start(signaller, audio, video)
+        webrtc::construct(signaller)
     }
 }
 

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -86,6 +86,7 @@ struct State {
     peer_id: Option<String>,
     media: Arc<ServoMedia>,
     webrtc: Option<Arc<WebRtcController>>,
+    signaller: Option<SignallerWrap>,
 }
 
 impl State {
@@ -113,10 +114,11 @@ impl State {
             self.app_state = AppState::PeerConnecting;
         }
         if self.peer_id.is_none() {
-            let signaller = SignallerWrap::new(self.send_msg_tx.clone());
+            let signaller = SignallerWrap::new(self.send_msg_tx.clone(), self.peer_id.is_some());
             let s = signaller.clone();
             self.webrtc = Some(self.media.create_webrtc_arc(Box::new(signaller)));
             s.0.lock().unwrap().1 = Some(Arc::downgrade(self.webrtc.as_ref().unwrap()));
+            self.signaller = Some(s);
         }
     }
 
@@ -125,15 +127,16 @@ impl State {
         assert_eq!(self.app_state, AppState::PeerConnecting);
         self.app_state = AppState::PeerConnected;
         if self.peer_id.is_some() {
-            let signaller = SignallerWrap::new(self.send_msg_tx.clone());
+            let signaller = SignallerWrap::new(self.send_msg_tx.clone(), self.peer_id.is_some());
             let s = signaller.clone();
             self.webrtc = Some(self.media.create_webrtc_arc(Box::new(signaller)));
             s.0.lock().unwrap().1 = Some(Arc::downgrade(self.webrtc.as_ref().unwrap()));
+            self.signaller = Some(s);
         }
     }
 }
 
-struct Signaller(mpsc::Sender<OwnedMessage>, Option<Weak<WebRtcController>>);
+struct Signaller(mpsc::Sender<OwnedMessage>, Option<Weak<WebRtcController>>, bool);
 
 #[derive(Clone)]
 struct SignallerWrap(Arc<Mutex<Signaller>>);
@@ -159,6 +162,9 @@ impl WebRtcSignaller for SignallerWrap {
     fn on_negotiation_needed(&self) {
         let s2 = self.0.clone();
         let signaller = self.0.lock().unwrap();
+        if !signaller.2 {
+            return
+        }
         let controller = signaller.1.as_ref().unwrap().upgrade().unwrap();
         let c2 = controller.clone();
         thread::spawn(move || {
@@ -185,8 +191,8 @@ impl Signaller {
 }
 
 impl SignallerWrap {
-    fn new(sender: mpsc::Sender<OwnedMessage>) -> Self {
-        let signaller = Signaller(sender, None);
+    fn new(sender: mpsc::Sender<OwnedMessage>, initiate: bool) -> Self {
+        let signaller = Signaller(sender, None, initiate);
         SignallerWrap(Arc::new(Mutex::new(signaller)))
     }
 }
@@ -243,7 +249,28 @@ fn receive_loop(
                                         type_: type_.parse().unwrap(),
                                         sdp: sdp.into()
                                     };
-                                    state.webrtc.as_ref().unwrap().set_remote_description(desc, (|| {}).into());
+                                    let controller = state.webrtc.as_ref().unwrap();
+                                    if state.peer_id.is_some() {
+                                        controller.set_remote_description(desc, (|| {}).into());
+                                    } else {
+                                        let c2 = controller.clone();
+                                        let c3 = controller.clone();
+                                        let s2 = state.signaller.clone().unwrap().0;
+                                        controller.set_remote_description(desc, (move || {
+                                            thread::spawn(move || {
+                                                c3.create_answer((move |answer: SessionDescription| {
+                                                    thread::spawn(move || {
+                                                        c2.set_local_description(answer.clone(), (move || {
+                                                            s2.lock().unwrap().send_sdp(answer);
+                                                        }).into());
+                                                    });
+
+                                                }).into());
+                                            });
+                                        }).into());
+                                    }
+                                    
+                                    
                                 }
                                 JsonMsg::Ice {
                                     sdp_mline_index,
@@ -302,6 +329,7 @@ fn run_example(servo_media: Arc<ServoMedia>) {
         peer_id: peer_id,
         media: servo_media,
         webrtc: None,
+        signaller: None,
     };
 
     let receive_loop = receive_loop(receiver, send_msg_tx, state);

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -119,6 +119,7 @@ impl State {
             self.webrtc = Some(self.media.create_webrtc_arc(Box::new(signaller)));
             s.0.lock().unwrap().1 = Some(Arc::downgrade(self.webrtc.as_ref().unwrap()));
             self.signaller = Some(s);
+            self.webrtc.as_ref().unwrap().init(&*ServoMedia::create_audiostream(), &*ServoMedia::create_videostream());
         }
     }
 
@@ -132,6 +133,7 @@ impl State {
             self.webrtc = Some(self.media.create_webrtc_arc(Box::new(signaller)));
             s.0.lock().unwrap().1 = Some(Arc::downgrade(self.webrtc.as_ref().unwrap()));
             self.signaller = Some(s);
+            self.webrtc.as_ref().unwrap().init(&*ServoMedia::create_audiostream(), &*ServoMedia::create_videostream());
         }
     }
 }

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -98,11 +98,7 @@ impl ServoMedia {
     }
 
     pub fn create_webrtc_arc(&self, signaller: Box<WebRtcSignaller>) -> Arc<WebRtcController> {
-        Arc::new(Backend::start_webrtc_controller(
-            signaller,
-            &*Self::create_audiostream(),
-            &*Self::create_videostream()),
-        )
+        Arc::new(Backend::construct_webrtc_controller(signaller))
     }
 
     pub fn create_audiostream() -> Box<MediaStream> {

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -10,6 +10,9 @@ pub trait MediaStream: Any {
 }
 
 pub trait WebRtcController: Send + Sync {
+    // currently simple_webrtc needs to be able to hook up the signaller after construction
+    // but before initialization. We split out init() to avoid a race.
+    fn init(&self, audio: &MediaStream, video: &MediaStream);
     fn notify_signal_server_error(&self);
     /// Invariant: Callback must not reentrantly invoke any methods on the controller
     fn set_remote_description(&self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
@@ -31,10 +34,8 @@ pub trait WebRtcSignaller: Send {
 pub trait WebRtcBackend {
     type Controller: WebRtcController;
 
-    fn start_webrtc_controller(
+    fn construct_webrtc_controller(
         signaller: Box<WebRtcSignaller>,
-        audio: &MediaStream,
-        video: &MediaStream,
     ) -> Self::Controller;
 }
 

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -17,6 +17,7 @@ pub trait WebRtcController: Send + Sync {
     fn set_local_description(&self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
     fn add_ice_candidate(&self, candidate: IceCandidate);
     fn create_offer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
+    fn create_answer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
     fn trigger_negotiation(&self);
 }
 


### PR DESCRIPTION
this allows the simple_webrtc to be the other side of the connection.

It's very hacky rn, but works.

Run one copy without a peer id, and use the printed peer id for the second


cc @jdm