### PR TITLE
Make backend also use event loop

### DIFF
--- a/backends/gstreamer/src/webrtc.rs
+++ b/backends/gstreamer/src/webrtc.rs
@@ -135,6 +135,16 @@ impl WebRtcControllerBackend for GStreamerWebRtcController {
             }
         }
     }
+
+
+
+    fn quit(&mut self) {
+        self.signaller.close();
+
+        self.pipeline.set_state(gst::State::Null).into_result().unwrap();
+
+        //main_loop.quit();
+    }
 }
 
 impl GStreamerWebRtcController {
@@ -162,23 +172,6 @@ impl GStreamerWebRtcController {
             .unwrap()
             .emit(kind, &[&answer, &promise])
             .unwrap();
-    }
-
-
-    #[allow(unused)]
-    fn close_and_quit(&self, err: &Error) {
-        println!("{}\nquitting", err);
-
-        // Must not hold mutex while shutting down the pipeline
-        // as something might call into here and take the mutex too
-        let pipeline = {
-            self.signaller.close(err.to_string());
-            self.pipeline.clone()
-        };
-
-        pipeline.set_state(gst::State::Null).into_result().unwrap();
-
-        //main_loop.quit();
     }
 }
 

--- a/backends/gstreamer/src/webrtc.rs
+++ b/backends/gstreamer/src/webrtc.rs
@@ -7,7 +7,8 @@ use gst_webrtc::{self, WebRTCSDPType};
 use media_stream::GStreamerMediaStream;
 use servo_media_webrtc::*;
 use servo_media_webrtc::WebRtcController as WebRtcThread;
-use std::sync::{Arc, Mutex};
+use servo_media_webrtc::thread::InternalEvent;
+use std::sync::Mutex;
 
 // TODO:
 // - remove use of failure?
@@ -37,173 +38,16 @@ enum AppState {
     PeerCallError,
 }
 
-#[derive(Clone)]
-pub struct GStreamerWebRtcController(Arc<Mutex<WebRtcControllerState>>);
-
 macro_rules! assert_state {
     ($controller:ident, $state:ident, $condition:expr, $string:expr) => {
         {
-            let $state = $controller.0.lock().unwrap().app_state;
+            let $state = $controller.app_state;
             assert!($condition, $string);
         }
     }
 }
 
-impl WebRtcControllerBackend for GStreamerWebRtcController {
-    fn add_ice_candidate(&self, candidate: IceCandidate) {
-        let app_control = self.0.lock().unwrap();
-        app_control
-            .webrtc
-            .as_ref()
-            .unwrap()
-            .emit("add-ice-candidate", &[&candidate.sdp_mline_index, &candidate.candidate])
-            .unwrap();
-    }
-
-    fn set_remote_description(&self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
-        assert_state!(self, state,
-                      state == AppState::PeerCallNegotiating || state == AppState::PeerCallNegotiatingHaveLocal,
-                      "Not ready to handle sdp");
-
-        self.set_description(desc, false, cb);
-
-        let mut app_control = self.0.lock().unwrap();
-        if app_control.app_state == AppState::PeerCallNegotiating {
-            app_control.app_state = AppState::PeerCallNegotiatingHaveRemote;
-        } else {
-            app_control.app_state = AppState::PeerCallStarted;
-        }
-    }
-
-    fn set_local_description(&self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
-        assert_state!(self, state,
-                      state == AppState::PeerCallNegotiating || state == AppState::PeerCallNegotiatingHaveRemote,
-                      "Not ready to handle sdp");
-
-        self.set_description(desc, true, cb);
-
-        let mut app_control = self.0.lock().unwrap();
-        if app_control.app_state == AppState::PeerCallNegotiating {
-            app_control.app_state = AppState::PeerCallNegotiatingHaveLocal;
-        } else {
-            app_control.app_state = AppState::PeerCallStarted;
-        }
-    }
-
-    fn create_offer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) {
-
-        let app_control_clone = self.clone();
-        let this = self.0.lock().unwrap();
-        let webrtc = this.webrtc.as_ref().unwrap();;
-        let promise = gst::Promise::new_with_change_func(move |promise| {
-            on_offer_or_answer_created(SdpType::Offer, app_control_clone, promise, cb);
-        });
-
-        webrtc.emit("create-offer", &[&None::<gst::Structure>, &promise]).unwrap();
-    }
-
-    fn create_answer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) {
-        let app_control_clone = self.clone();
-        let this = self.0.lock().unwrap();
-        let webrtc = this.webrtc.as_ref().unwrap();;
-        let promise = gst::Promise::new_with_change_func(move |promise| {
-            on_offer_or_answer_created(SdpType::Answer, app_control_clone, promise, cb);
-        });
-
-        webrtc.emit("create-answer", &[&None::<gst::Structure>, &promise]).unwrap();
-    } 
-
-    fn add_stream(&self, stream: &MediaStream) {
-        println!("adding a stream");
-        let (pipeline, webrtc) = {
-            let mut controller = self.0.lock().unwrap();
-            (controller.pipeline.clone(), controller.webrtc.clone().unwrap())
-        };
-        let stream = stream.as_any().downcast_ref::<GStreamerMediaStream>().unwrap();
-        stream.attach_to_pipeline(&pipeline, &webrtc);
-        self.0.lock().unwrap().prepare_for_negotiation(self.clone());
-    }
-
-    fn configure(&self, stun_server: &str, policy: BundlePolicy) {
-        let data = self.0.lock().unwrap();
-        let webrtc = data.webrtc.as_ref().unwrap();
-        webrtc.set_property_from_str("stun-server", stun_server);
-        webrtc.set_property_from_str("bundle-policy", policy.as_str());
-    }
-}
-
-impl GStreamerWebRtcController {
-    fn process_new_stream(
-        &self,
-        values: &[glib::Value],
-        pipe: &gst::Pipeline,
-    ) -> Option<glib::Value> {
-        let pad = values[1].get::<gst::Pad>().expect("not a pad??");
-        if pad.get_direction() != PadDirection::Src {
-            // Ignore outgoing pad notifications.
-            return None;
-        }
-        on_incoming_stream(self, values, pipe)
-    }
-
-    fn set_description(&self, desc: SessionDescription, local: bool, cb: SendBoxFnOnce<'static, ()>) {
-        let ty = match desc.type_ {
-            SdpType::Answer => WebRTCSDPType::Answer,
-            SdpType::Offer => WebRTCSDPType::Offer,
-            SdpType::Pranswer => WebRTCSDPType::Pranswer,
-            SdpType::Rollback => WebRTCSDPType::Rollback,
-        };
-
-        let kind = if local { "set-local-description" } else { "set-remote-description" };
-
-        let app_control = self.0.lock().unwrap();
-        let ret = gst_sdp::SDPMessage::parse_buffer(desc.sdp.as_bytes()).unwrap();
-        let answer =
-            gst_webrtc::WebRTCSessionDescription::new(ty, ret);
-        let promise = gst::Promise::new_with_change_func(move |_promise| {
-            cb.call()
-        });
-        app_control
-            .webrtc
-            .as_ref()
-            .unwrap()
-            .emit(kind, &[&answer, &promise])
-            .unwrap();
-    }
-
-    //#[allow(unused)]
-    fn send_bus_error(&self, body: &str) {
-        eprintln!("Bus error: {}", body);
-        /*let mbuilder =
-            gst::Message::new_application(gst::Structure::new("error", &[("body", &body)]));
-        let _ = self.0.lock().unwrap().bus.post(&mbuilder.build());*/
-        //XXXjdm
-    }
-
-    #[allow(unused)]
-    fn update_state(&self, state: AppState) {
-        self.0.lock().unwrap().update_state(state);
-    }
-
-    #[allow(unused)]
-    fn close_and_quit(&self, err: &Error) {
-        println!("{}\nquitting", err);
-
-        // Must not hold mutex while shutting down the pipeline
-        // as something might call into here and take the mutex too
-        let pipeline = {
-            let app_control = self.0.lock().unwrap();
-            app_control.signaller.close(err.to_string());
-            app_control.pipeline.clone()
-        };
-
-        pipeline.set_state(gst::State::Null).into_result().unwrap();
-
-        //main_loop.quit();
-    }
-}
-
-struct WebRtcControllerState {
+pub struct GStreamerWebRtcController {
     webrtc: Option<gst::Element>,
     app_state: AppState,
     pipeline: gst::Pipeline,
@@ -216,52 +60,177 @@ struct WebRtcControllerState {
     //bus: gst::Bus,
 }
 
-impl WebRtcControllerState {
-    fn prepare_for_negotiation(&mut self, target: GStreamerWebRtcController) {
+impl WebRtcControllerBackend for GStreamerWebRtcController {
+    fn add_ice_candidate(&mut self, candidate: IceCandidate) {
+        self
+            .webrtc
+            .as_ref()
+            .unwrap()
+            .emit("add-ice-candidate", &[&candidate.sdp_mline_index, &candidate.candidate])
+            .unwrap();
+    }
+
+    fn set_remote_description(&mut self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
+        assert_state!(self, state,
+                      state == AppState::PeerCallNegotiating || state == AppState::PeerCallNegotiatingHaveLocal,
+                      "Not ready to handle sdp");
+
+        self.set_description(desc, false, cb);
+
+        if self.app_state == AppState::PeerCallNegotiating {
+            self.app_state = AppState::PeerCallNegotiatingHaveRemote;
+        } else {
+            self.app_state = AppState::PeerCallStarted;
+        }
+    }
+
+    fn set_local_description(&mut self, desc: SessionDescription, cb: SendBoxFnOnce<'static, ()>) {
+        assert_state!(self, state,
+                      state == AppState::PeerCallNegotiating || state == AppState::PeerCallNegotiatingHaveRemote,
+                      "Not ready to handle sdp");
+
+        self.set_description(desc, true, cb);
+
+        if self.app_state == AppState::PeerCallNegotiating {
+            self.app_state = AppState::PeerCallNegotiatingHaveLocal;
+        } else {
+            self.app_state = AppState::PeerCallStarted;
+        }
+    }
+
+    fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) {
+        let webrtc = self.webrtc.as_ref().unwrap();
+        assert_state!(self, state, state == AppState::PeerCallNegotiating,
+                      "Not negotiating call when creating offer");
+        let promise = gst::Promise::new_with_change_func(move |promise| {
+            on_offer_or_answer_created(SdpType::Offer, promise, cb);
+        });
+
+        webrtc.emit("create-offer", &[&None::<gst::Structure>, &promise]).unwrap();
+    }
+
+    fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>) {
+        let webrtc = self.webrtc.as_ref().unwrap();
+        assert_state!(self, state, state == AppState::PeerCallNegotiatingHaveRemote,
+                      "No offfer received when creating answer");
+        let promise = gst::Promise::new_with_change_func(move |promise| {
+            on_offer_or_answer_created(SdpType::Answer, promise, cb);
+        });
+
+        webrtc.emit("create-answer", &[&None::<gst::Structure>, &promise]).unwrap();
+    } 
+
+    fn add_stream(&mut self, stream: &MediaStream) {
+        println!("adding a stream");
+        let stream = stream.as_any().downcast_ref::<GStreamerMediaStream>().unwrap();
+        stream.attach_to_pipeline(&self.pipeline, self.webrtc.as_ref().unwrap());
+        self.prepare_for_negotiation();
+    }
+
+    fn configure(&mut self, stun_server: &str, policy: BundlePolicy) {
+        let webrtc = self.webrtc.as_ref().unwrap();
+        webrtc.set_property_from_str("stun-server", stun_server);
+        webrtc.set_property_from_str("bundle-policy", policy.as_str());
+    }
+
+    fn internal_event(&mut self, e: thread::InternalEvent) {
+        match e {
+            InternalEvent::OnNegotiationNeeded => {
+                self.app_state = AppState::PeerCallNegotiating;
+                self.signaller.on_negotiation_needed(&self.thread);
+            }
+            InternalEvent::OnIceCandidate(candidate) => {
+                self.signaller.on_ice_candidate(&self.thread, candidate);
+            }
+        }
+    }
+}
+
+impl GStreamerWebRtcController {
+
+
+    fn set_description(&self, desc: SessionDescription, local: bool, cb: SendBoxFnOnce<'static, ()>) {
+        let ty = match desc.type_ {
+            SdpType::Answer => WebRTCSDPType::Answer,
+            SdpType::Offer => WebRTCSDPType::Offer,
+            SdpType::Pranswer => WebRTCSDPType::Pranswer,
+            SdpType::Rollback => WebRTCSDPType::Rollback,
+        };
+
+        let kind = if local { "set-local-description" } else { "set-remote-description" };
+
+        let ret = gst_sdp::SDPMessage::parse_buffer(desc.sdp.as_bytes()).unwrap();
+        let answer =
+            gst_webrtc::WebRTCSessionDescription::new(ty, ret);
+        let promise = gst::Promise::new_with_change_func(move |_promise| {
+            cb.call()
+        });
+        self
+            .webrtc
+            .as_ref()
+            .unwrap()
+            .emit(kind, &[&answer, &promise])
+            .unwrap();
+    }
+
+
+    #[allow(unused)]
+    fn close_and_quit(&self, err: &Error) {
+        println!("{}\nquitting", err);
+
+        // Must not hold mutex while shutting down the pipeline
+        // as something might call into here and take the mutex too
+        let pipeline = {
+            self.signaller.close(err.to_string());
+            self.pipeline.clone()
+        };
+
+        pipeline.set_state(gst::State::Null).into_result().unwrap();
+
+        //main_loop.quit();
+    }
+}
+
+impl GStreamerWebRtcController {
+    fn prepare_for_negotiation(&mut self) {
         if self.ready_to_negotiate {
             return;
         }
         self.ready_to_negotiate = true;
         let webrtc = self.webrtc.as_ref().unwrap();
+        // gstreamer needs Sync on these callbacks for some reason
+        // https://github.com/sdroege/gstreamer-rs/issues/154
+        let thread = Mutex::new(self.thread.clone());
         // If the pipeline starts playing and this signal is present before there are any
         // media streams, an invalid SDP offer will be created. Therefore, delay setting up
         // the signal and starting the pipeline until after the first stream has been added.
         webrtc.connect("on-negotiation-needed", false, move |_values| {
-            println!("on-negotiation-needed");
-            let mut control = target.0.lock().unwrap();
-            control.app_state = AppState::PeerCallNegotiating;
-            control.signaller.on_negotiation_needed(&control.thread);
+            thread.lock().unwrap().internal_event(InternalEvent::OnNegotiationNeeded);
             None
         }).unwrap();
         self.pipeline.set_state(gst::State::Playing).into_result().unwrap();
     }
 
-    fn start_pipeline(&mut self, target: GStreamerWebRtcController) {
+    fn start_pipeline(&mut self) {
         let webrtc = gst::ElementFactory::make("webrtcbin", "sendrecv").unwrap();
         self.pipeline.add(&webrtc).unwrap();
 
-        let app_control_clone = target.clone();
+        // gstreamer needs Sync on these callbacks for some reason
+        // https://github.com/sdroege/gstreamer-rs/issues/154
+        let thread = Mutex::new(self.thread.clone());
         webrtc.connect("on-ice-candidate", false, move |values| {
-            println!("on-ice-candidate");
-            send_ice_candidate_message(&app_control_clone, values);
+            thread.lock().unwrap().internal_event(InternalEvent::OnIceCandidate(candidate(values)));
             None
         }).unwrap();
 
         let pipe_clone = self.pipeline.clone();
-        let app_control_clone = target.clone();
         webrtc.connect("pad-added", false, move |values| {
             println!("pad-added");
-            app_control_clone.process_new_stream(
-                values,
-                &pipe_clone,
-            )
+            process_new_stream(values, &pipe_clone);
+            None
         }).unwrap();
 
         self.webrtc = Some(webrtc);
-    }
-
-    fn update_state(&mut self, state: AppState) {
-        self.app_state = state;
     }
 }
 
@@ -272,7 +241,7 @@ pub fn construct(
     let main_loop = glib::MainLoop::new(None, false);
     let pipeline = gst::Pipeline::new("main");
 
-    let controller = WebRtcControllerState {
+    let mut controller = GStreamerWebRtcController {
         webrtc: None,
         pipeline,
         signaller,
@@ -281,26 +250,17 @@ pub fn construct(
         ready_to_negotiate: false,
         _main_loop: main_loop,
     };
-    let controller = GStreamerWebRtcController(Arc::new(Mutex::new(controller)));
-    controller.0.lock().unwrap().start_pipeline(controller.clone());
+    controller.start_pipeline();
     controller
     
 }
 
 fn on_offer_or_answer_created(
     ty: SdpType,
-    app_control: GStreamerWebRtcController,
     promise: &gst::Promise,
     cb: SendBoxFnOnce<'static, (SessionDescription,)>,
 ) {
     debug_assert!(ty == SdpType::Offer || ty == SdpType::Answer);
-    if ty == SdpType::Offer {
-        assert_state!(app_control, state, state == AppState::PeerCallNegotiating,
-                      "Not negotiating call when creating offer")
-    } else {
-        assert_state!(app_control, state, state == AppState::PeerCallNegotiatingHaveRemote,
-                      "No offfer received when creating answer")
-    }
 
     let reply = promise.get_reply().unwrap();
 
@@ -368,7 +328,6 @@ fn handle_media_stream(
 }
 
 fn on_incoming_decodebin_stream(
-    app_control: &GStreamerWebRtcController,
     values: &[glib::Value],
     pipe: &gst::Pipeline,
 ) -> Option<glib::Value> {
@@ -391,14 +350,13 @@ fn on_incoming_decodebin_stream(
     };
 
     if let Err(err) = handled {
-        app_control.send_bus_error(&format!("Error adding pad with caps {} {:?}", name, err));
+        eprintln!("Error adding pad with caps {} {:?}", name, err);
     }
 
     None
 }
 
 fn on_incoming_stream(
-    app_control: &GStreamerWebRtcController,
     values: &[glib::Value],
     pipe: &gst::Pipeline,
 ) -> Option<glib::Value> {
@@ -406,11 +364,10 @@ fn on_incoming_stream(
 
     let decodebin = gst::ElementFactory::make("decodebin", None).unwrap();
     let pipe_clone = pipe.clone();
-    let app_control_clone = app_control.clone();
     decodebin
         .connect("pad-added", false, move |values| {
             println!("decodebin pad-added");
-            on_incoming_decodebin_stream(&app_control_clone, values, &pipe_clone)
+            on_incoming_decodebin_stream(values, &pipe_clone)
         })
         .unwrap();
 
@@ -422,17 +379,25 @@ fn on_incoming_stream(
     None
 }
 
-fn send_ice_candidate_message(app_control: &GStreamerWebRtcController, values: &[glib::Value]) {
-    assert_state!(app_control, state, state >= AppState::PeerCallNegotiating, "Can't send ICE, not in call");
+fn process_new_stream(
+    values: &[glib::Value],
+    pipe: &gst::Pipeline,
+) -> Option<glib::Value> {
+    let pad = values[1].get::<gst::Pad>().expect("not a pad??");
+    if pad.get_direction() != PadDirection::Src {
+        // Ignore outgoing pad notifications.
+        return None;
+    }
+    on_incoming_stream(values, pipe)
+}
 
+fn candidate(values: &[glib::Value]) -> IceCandidate {
     let _webrtc = values[0].get::<gst::Element>().expect("Invalid argument");
     let sdp_mline_index = values[1].get::<u32>().expect("Invalid argument");
     let candidate = values[2].get::<String>().expect("Invalid argument");
 
-    let candidate = IceCandidate {
+    IceCandidate {
         sdp_mline_index,
         candidate,
-    };
-    let control = app_control.0.lock().unwrap();
-    control.signaller.on_ice_candidate(&control.thread, candidate);
+    }
 }

--- a/examples/simple_webrtc.rs
+++ b/examples/simple_webrtc.rs
@@ -161,10 +161,10 @@ struct Signaller {
 }
 
 impl WebRtcSignaller for Signaller {
-    fn close(&self, reason: String) {
+    fn close(&self) {
         let _ = self.sender.send(OwnedMessage::Close(Some(websocket::message::CloseData {
             status_code: 1011, //Internal Error
-            reason: reason,
+            reason: "explicitly closed".into(),
         })));
     }
 

--- a/servo-media/src/lib.rs
+++ b/servo-media/src/lib.rs
@@ -15,6 +15,7 @@ use audio::sink::{AudioSinkError, DummyAudioSink};
 use audio::AudioBackend;
 use player::{DummyPlayer, Player, PlayerBackend};
 use webrtc::{WebRtcController, WebRtcSignaller, MediaStream};
+use webrtc::{WebRtcBackend, DummyWebRtcController};
 
 pub struct ServoMedia;
 
@@ -44,6 +45,16 @@ impl PlayerBackend for DummyBackend {
     type Player = DummyPlayer;
     fn make_player() -> Self::Player {
         DummyPlayer {}
+    }
+}
+
+impl WebRtcBackend for DummyBackend {
+    type Controller = DummyWebRtcController;
+    fn construct_webrtc_controller(
+        _: Box<WebRtcSignaller>,
+        _: WebRtcController,
+    ) -> Self::Controller {
+        DummyWebRtcController
     }
 }
 

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -24,6 +24,7 @@ pub trait WebRtcControllerBackend: Send {
     fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
     fn add_stream(&mut self, stream: &MediaStream);
     fn internal_event(&mut self, event: thread::InternalEvent);
+    fn quit(&mut self);
 }
 
 pub struct DummyWebRtcController;
@@ -37,13 +38,14 @@ impl WebRtcControllerBackend for DummyWebRtcController {
     fn create_answer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) {}
     fn add_stream(&mut self, _: &MediaStream) {}
     fn internal_event(&mut self, _: thread::InternalEvent) {}
+    fn quit(&mut self) {}
 }
 
 pub trait WebRtcSignaller: Send {
     fn on_ice_candidate(&self, controller: &WebRtcController, candidate: IceCandidate);
     /// Invariant: Must not reentrantly invoke any methods on the controller
     fn on_negotiation_needed(&self, controller: &WebRtcController);
-    fn close(&self, reason: String);
+    fn close(&self);
 }
 
 pub trait WebRtcBackend {

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -17,15 +17,26 @@ pub use thread::WebRtcController;
 /// the client. Use WebRtcController instead
 pub trait WebRtcControllerBackend: Send {
     fn configure(&mut self, stun_server: &str, policy: BundlePolicy);
-    /// Invariant: Callback must not reentrantly invoke any methods on the controller
     fn set_remote_description(&mut self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
-    /// Invariant: Callback must not reentrantly invoke any methods on the controller
     fn set_local_description(&mut self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
     fn add_ice_candidate(&mut self, candidate: IceCandidate);
     fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
     fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
     fn add_stream(&mut self, stream: &MediaStream);
     fn internal_event(&mut self, event: thread::InternalEvent);
+}
+
+pub struct DummyWebRtcController;
+
+impl WebRtcControllerBackend for DummyWebRtcController {
+    fn configure(&mut self, _: &str, _: BundlePolicy) {}
+    fn set_remote_description(&mut self, _: SessionDescription, _: SendBoxFnOnce<'static, ()>) {}
+    fn set_local_description(&mut self, _: SessionDescription, _: SendBoxFnOnce<'static, ()>) {}
+    fn add_ice_candidate(&mut self, _: IceCandidate) {}
+    fn create_offer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) {}
+    fn create_answer(&mut self, _: SendBoxFnOnce<'static, (SessionDescription,)>) {}
+    fn add_stream(&mut self, _: &MediaStream) {}
+    fn internal_event(&mut self, _: thread::InternalEvent) {}
 }
 
 pub trait WebRtcSignaller: Send {

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -15,16 +15,17 @@ pub use thread::WebRtcController;
 
 /// This trait is implemented by backends and should never be used directly by
 /// the client. Use WebRtcController instead
-pub trait WebRtcControllerBackend: Send + Sync {
-    fn configure(&self, stun_server: &str, policy: BundlePolicy);
+pub trait WebRtcControllerBackend: Send {
+    fn configure(&mut self, stun_server: &str, policy: BundlePolicy);
     /// Invariant: Callback must not reentrantly invoke any methods on the controller
-    fn set_remote_description(&self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
+    fn set_remote_description(&mut self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
     /// Invariant: Callback must not reentrantly invoke any methods on the controller
-    fn set_local_description(&self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
-    fn add_ice_candidate(&self, candidate: IceCandidate);
-    fn create_offer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
-    fn create_answer(&self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
-    fn add_stream(&self, stream: &MediaStream);
+    fn set_local_description(&mut self, SessionDescription, cb: SendBoxFnOnce<'static, ()>);
+    fn add_ice_candidate(&mut self, candidate: IceCandidate);
+    fn create_offer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
+    fn create_answer(&mut self, cb: SendBoxFnOnce<'static, (SessionDescription,)>);
+    fn add_stream(&mut self, stream: &MediaStream);
+    fn internal_event(&mut self, event: thread::InternalEvent);
 }
 
 pub trait WebRtcSignaller: Send {


### PR DESCRIPTION
This removes all the ad-hoc synchronization in favor of driving events through a single event loop.


This also adds a dummy webrtc backend so this crate can compile on platforms without gstreamer.


r? @jdm